### PR TITLE
#60: Bugfix - Neglected to update the Netlify functions

### DIFF
--- a/functions/common/utils.js
+++ b/functions/common/utils.js
@@ -1,4 +1,12 @@
-import members from '../../data/members.json'
+let glob = require("glob");
+let path = require("path");
+
+let members = [];
+
+glob.sync("./data/members/*.json").forEach(function (file) {
+    let contents = require(path.resolve(file));
+    members.push(contents);
+});
 
 export const redirect = site => {
     const statusMessage = `redirecting to: ${site.url}`

--- a/functions/common/utils.js
+++ b/functions/common/utils.js
@@ -8,6 +8,10 @@ glob.sync("./data/members/*.json").forEach(function (file) {
     members.push(contents);
 });
 
+members.sort((a, b) => {
+    return a.date > b.date ? 1 : -1;
+})
+
 export const redirect = site => {
     const statusMessage = `redirecting to: ${site.url}`
     console.log(statusMessage)


### PR DESCRIPTION
I had neglected to update the Netlify functions that relied on the previous format of all members in one static file. Changed to use `glob` to import all files into the members array instead. Sorting this array by the same date-based sorting method used on the site.

While this is working in my local tests, I'm not familiar enough with how Netlify caches the data in these functions so I can't tell if the `members` list is generated once on build or if it happens on each request. Running locally, going to any of the `next`, `prevous`, or `random` links redirects me almost instantly but that's not indicative of live performance. Possible to verify?