### PR TITLE
Fix Alicia Jarvis

### DIFF
--- a/data/members/Alicia Jarvis.json
+++ b/data/members/Alicia Jarvis.json
@@ -8,6 +8,6 @@
   },
   "linkedin": "https://www.linkedin.com/in/aliciajarvis/",
   "mastodon": "https://mastodon.social/@A11yAlicia",
-  "rss": "https://www.alicia.design/blog-feed.xml"
+  "rss": null,
   "twitter": "https://twitter.com/a11yalicia"
 }


### PR DESCRIPTION
This PR adds `.json` to Alicia Jarvis' entry and removes her RSS link (requested offsite). This should hopefully address https://github.com/ericwbailey/a11y-webring.club/issues/88.