### PR TITLE
Add h3 mark-up to each name within the 'Members' list

### DIFF
--- a/includes/members.njk
+++ b/includes/members.njk
@@ -7,11 +7,11 @@
 <ul class="flow-3 members">
 {% for key, member in members | sortDataByDate %}
   <li class="member">
-    <span class="name-lockup">
+    <h3 class="name-lockup">
       <a href="{{ member.url }}">{{ member.name }}</a>
       {% if member.employment.hiring %} <span class="hiring">hiring</span>{% endif %}
       {% if member.employment.seeking %} <span class="seeking">seeking work</span>{% endif %}
-    </span>
+    </h3>
 
     <ul class="contact">
       {% if member.linkedin %}


### PR DESCRIPTION
## New feature

This PR adds a level 3 heading around each name (and employment status text where applicable) within the "Members" list.  In keeping with the first rule of ARIA, I used `<h3>` mark-up directly, which opefully doesn't change the visual styling.  If it does, we could consider an alternative like:

```
<span class="name-lockup" role="heading" aria-level="3">
	...
</span>
```

... or just fix the styling.

### GitHub issue

Closes https://github.com/ericwbailey/a11y-webring.club/issues/148.

- [x] I agree to follow this project's code of conduct