### PR TITLE
Adds Jason Morris

### DIFF
--- a/data/members/Jason Morris.json
+++ b/data/members/Jason Morris.json
@@ -1,0 +1,14 @@
+{
+  "date": "2023-11-13T00:00",
+  "name": "Jason Morris",
+  "url": "https://jasonmorris.com",
+  "employment": {
+    "hiring": false,
+    "seeking": false
+  },
+  "github": "https://github.com/jsnmrs",
+  "linkedin": "https://www.linkedin.com/in/jsnmrs/",
+  "accessibilityStatement": "https://jasonmorris.com/accessibility",
+  "mastodon": "https://indieweb.social/@jasonmorris",
+  "rss": "https://jasonmorris.com/atom.xml"
+}


### PR DESCRIPTION
This pull request adds [my personal website](https://jasonmorris.com) and info to the A11y webring. The webring links were added to the bottom of the home page in https://github.com/jsnmrs/jasonmorris/pull/668. Thanks!