### PR TITLE
Remove Twitter and employment member metadata

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Unfortunately, this is something that will break the webring. Since you do not o
 
 ## I want to suggest a new social media service to add
 
-I'm definitely open to suggestions! I will not allow Twitter/X or Threads, due to ethical issues I have with each platform.
+I'm definitely open to suggestions! I will not allow [Twitter/X](https://twitter.com/) or [Threads](https://www.threads.net/), due to ethical issues I have with each platform.
 
 If you have a suggestion for a service other than those two, please [create an issue](https://github.com/ericwbailey/a11y-webring.club/issues/new) so we can chat it out.
 

--- a/data/members/Adam Norris.json
+++ b/data/members/Adam Norris.json
@@ -2,13 +2,8 @@
   "date": "2023-01-19T00:00",
   "name": "Adam Norris",
   "url": "https://acnorris.uk",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/adam-norris-ab2590a0/?originalSubdomain=uk",
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/acnorrisuk?lang=en"
+  "rss": null
 }

--- a/data/members/Alicia Jarvis.json
+++ b/data/members/Alicia Jarvis.json
@@ -2,13 +2,8 @@
   "date": "2023-02-11T00:00",
   "name": "Alicia Jarvis",
   "url": "https://aliciajarvis.github.io/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/aliciajarvis/",
   "mastodon": "https://mastodon.social/@A11yAlicia",
-  "rss": null,
-  "twitter": "https://twitter.com/a11yalicia"
+  "rss": null
 }

--- a/data/members/Andrew Hedges.json
+++ b/data/members/Andrew Hedges.json
@@ -2,13 +2,8 @@
   "date": "2023-01-20T07:20",
   "name": "Andrew Hedges",
   "url": "https://andrew.hedges.name/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/segdeha",
   "linkedin": "https://www.linkedin.com/in/andrewhedges/",
   "mastodon": "https://mastodon.social/@segdeha",
-  "rss": null,
-  "twitter": "https://twitter.com/segdeha"
+  "rss": null
 }

--- a/data/members/Annabelle Feiler.json
+++ b/data/members/Annabelle Feiler.json
@@ -2,13 +2,8 @@
   "date": "2024-01-09T00:00",
   "name": "Annabelle Feiler",
   "url": "https://annabelle-feiler.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/annabelle-feiler/",
   "mastodon": null,
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Anne Sturdivant.json
+++ b/data/members/Anne Sturdivant.json
@@ -2,10 +2,6 @@
   "date": "2023-10-05T00:00",
   "name": "Anne Sturdivant",
   "url": "https://weblog.anniegreens.lol/webrings",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/anniegreens",
   "linkedin": "https://www.linkedin.com/in/anniegreens",
   "mastodon": "https://social.lol/@anniegreens",

--- a/data/members/Brian DeConinck.json
+++ b/data/members/Brian DeConinck.json
@@ -2,13 +2,8 @@
   "date": "2023-01-26T19:31",
   "name": "Brian DeConinck",
   "url": "https://www.briandeconinck.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/bdeconinck/",
   "mastodon": null,
-  "rss": "https://www.briandeconinck.com/notes/feed/",
-  "twitter": null
+  "rss": "https://www.briandeconinck.com/notes/feed/"
 }

--- a/data/members/Bruno Pulis.json
+++ b/data/members/Bruno Pulis.json
@@ -2,13 +2,8 @@
   "date": "2024-03-22T00:00",
   "name": "Bruno Pulis",
   "url": "https://brunopulis.com",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": "https://github.com/brunopulis",
   "linkedin": "https://www.linkedin.com/in/pulis/",
   "mastodon": null,
-  "rss": "https://brunopulis.com/feed/",
-  "twitter": "https://twitter.com/obrunopulis"
+  "rss": "https://brunopulis.com/feed/"
 }

--- a/data/members/Chris Yoong.json
+++ b/data/members/Chris Yoong.json
@@ -2,13 +2,8 @@
   "date": "2023-10-02T12:29",
   "name": "Chris Yoong",
   "url": "https://chrisyoong.com",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": "https://github.com/chris-gds",
   "linkedin": "https://www.linkedin.com/in/chrisyoong/",
   "mastodon": null,
-  "rss": "https://chrisyoong.com/api/rss.xml",
-  "twitter": null
+  "rss": "https://chrisyoong.com/api/rss.xml"
 }

--- a/data/members/Cristian Díaz.json
+++ b/data/members/Cristian Díaz.json
@@ -2,13 +2,8 @@
   "date": "2023-01-25T16:54",
   "name": "Cristian Díaz",
   "url": "https://www.itscrisdiaz.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": "https://github.com/ItsCrisDiaz",
   "linkedin": "https://www.linkedin.com/in/itscrisdiaz/",
   "mastodon": "https://mastodon.social/@ItsCrisDiaz",
-  "rss": null,
-  "twitter": "https://twitter.com/ItsCrisDiaz"
+  "rss": null
 }

--- a/data/members/DJ Chase.json
+++ b/data/members/DJ Chase.json
@@ -2,13 +2,8 @@
   "date": "2023-05-04T23:25",
   "name": "DJ Chase",
   "url": "https://dj-chase.com/meta/rings-and-clubs.gmi",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": null,
-  "rss": "https://dj-chase.com/documents/feed.xml",
-  "twitter": null
+  "rss": "https://dj-chase.com/documents/feed.xml"
 }

--- a/data/members/Daniel Henderson-Ede.json
+++ b/data/members/Daniel Henderson-Ede.json
@@ -2,14 +2,9 @@
   "date": "2023-12-20T00:00",
   "name": "Daniel Henderson-Ede",
   "url": "https://daniel.hendersonede.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "accessibilityStatement": "https://daniel.hendersonede.com/accessibility-statement/",
   "github": "https://github.com/danhendersonede",
   "linkedin": "https://www.linkedin.com/in/danhendersonede/",
   "mastodon": null,
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Daniela Kubesch.json
+++ b/data/members/Daniela Kubesch.json
@@ -2,13 +2,8 @@
   "date": "2023-01-30T12:34",
   "name": "Daniela Kubesch",
   "url": "https://dnikub.dev/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/danikubesch/",
   "mastodon": "https://front-end.social/@dnikub",
-  "rss": "https://dnikub.dev/feed.xml",
-  "twitter": "https://twitter.com/dnikub"
+  "rss": "https://dnikub.dev/feed.xml"
 }

--- a/data/members/Darek Kay.json
+++ b/data/members/Darek Kay.json
@@ -2,13 +2,8 @@
   "date": "2023-06-08T13:45",
   "name": "Darek Kay",
   "url": "https://darekkay.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://fosstodon.org/@darekkay",
-  "rss": "https://darekkay.com/atom.xml",
-  "twitter": null
+  "rss": "https://darekkay.com/atom.xml"
 }

--- a/data/members/Darin Senneff.json
+++ b/data/members/Darin Senneff.json
@@ -2,13 +2,8 @@
   "date": "2023-02-05T00:00",
   "name": "Darin Senneff",
   "url": "https://darins.page",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://mas.to/@darin",
-  "rss": "https://www.darins.page/articles/feed",
-  "twitter": "https://twitter.com/dsenneff"
+  "rss": "https://www.darins.page/articles/feed"
 }

--- a/data/members/Daryl Sun.json
+++ b/data/members/Daryl Sun.json
@@ -3,13 +3,8 @@
   "name": "Daryl Sun",
   "url": "https://blog.darylsun.page/",
   "accessibilityStatement": "https://blog.darylsun.page/colophon",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://social.lol/@darylsun",
-  "rss": "https://blog.darylsun.page/rss.xml",
-  "twitter": null
+  "rss": "https://blog.darylsun.page/rss.xml"
 }

--- a/data/members/David A Kennedy.json
+++ b/data/members/David A Kennedy.json
@@ -2,13 +2,8 @@
   "date": "2023-01-27T02:11",
   "name": "David A. Kennedy",
   "url": "https://davidakennedy.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/davidakennedy/",
   "mastodon": null,
-  "rss": "https://davidakennedy.com/feed/",
-  "twitter": "https://twitter.com/davidakennedy"
+  "rss": "https://davidakennedy.com/feed/"
 }

--- a/data/members/Dennis Lembree.json
+++ b/data/members/Dennis Lembree.json
@@ -2,13 +2,8 @@
   "date": "2023-02-01T13:26",
   "name": "Dennis Lembree",
   "url": "https://www.dennislembree.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/lembree/",
   "mastodon": "https://mastodon.social/@dennisl",
-  "rss": "https://www.webaxe.org/feed/",
-  "twitter": "https://twitter.com/dennisl"
+  "rss": "https://www.webaxe.org/feed/"
 }

--- a/data/members/Devon Persing.json
+++ b/data/members/Devon Persing.json
@@ -2,13 +2,8 @@
   "date": "2023-05-03T00:00",
   "name": "Devon Persing",
   "url": "https://dpersing.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/devonpersing/",
   "mastodon": "https://octodon.social/@viscousplatypus",
-  "rss": "https://devonpersing.netlify.app/feed.xml",
-  "twitter": "https://twitter.com/devonpersing"
+  "rss": "https://devonpersing.netlify.app/feed.xml"
 }

--- a/data/members/Dylan Thomas.json
+++ b/data/members/Dylan Thomas.json
@@ -2,13 +2,8 @@
   "date": "2023-01-23T15:34",
   "name": "Dylan Thomas",
   "url": "https://dht.is",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/dylanhthomas/",
   "mastodon": null,
-  "rss": "https://dht.is/writing/index.xml",
-  "twitter": null
+  "rss": "https://dht.is/writing/index.xml"
 }

--- a/data/members/EJ Mason.json
+++ b/data/members/EJ Mason.json
@@ -2,13 +2,8 @@
   "date": "2023-01-21T01:09",
   "name": "EJ Mason",
   "url": "https://www.ejmason.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/mxmason/",
   "mastodon": "https://front-end.social/@codeability",
-  "rss": null,
-  "twitter": "https://twitter.com/codeability"
+  "rss": null
 }

--- a/data/members/Eli Mellen.json
+++ b/data/members/Eli Mellen.json
@@ -2,13 +2,8 @@
   "date": "2023-02-08T00:00",
   "name": "Eli Mellen",
   "url": "https://eli.li",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/eli-mellen/",
   "mastodon": "https://tenforward.social/@eli_oat",
-  "rss": "https://eli.li/feed.rss",
-  "twitter": false
+  "rss": "https://eli.li/feed.rss"
 }

--- a/data/members/Elizabeth McCready.json
+++ b/data/members/Elizabeth McCready.json
@@ -2,13 +2,8 @@
   "date": "2023-11-08T00:00",
   "name": "Elizabeth McCready",
   "url": "https://gingerkiwi.dev",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/elizabethmccready",
   "mastodon": null,
-  "rss": "https://gingerkiwi.dev/feed.xml",
-  "twitter": null
+  "rss": "https://gingerkiwi.dev/feed.xml"
 }

--- a/data/members/Eric Bailey.json
+++ b/data/members/Eric Bailey.json
@@ -2,13 +2,8 @@
   "date": "2023-01-19T00:00",
   "name": "Eric Bailey",
   "url": "https://ericwbailey.website/colophon/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/ericwbailey",
   "linkedin": "https://www.linkedin.com/in/ericwbailey/",
   "mastodon": "https://social.ericwbailey.website/@eric",
-  "rss": "https://ericwbailey.website/feed/feed.xml",
-  "twitter": "https://twitter.com/ericwbailey"
+  "rss": "https://ericwbailey.website/feed/feed.xml"
 }

--- a/data/members/Eric Eggert.json
+++ b/data/members/Eric Eggert.json
@@ -2,13 +2,8 @@
   "date": "2023-01-21T09:02",
   "name": "Eric Eggert",
   "url": "https://yatil.net/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "http://linkedin.com/in/yatil/",
   "mastodon": "https://toot.cafe/@yatil",
-  "rss": "https://yatil.net/feed",
-  "twitter": null
+  "rss": "https://yatil.net/feed"
 }

--- a/data/members/Esrah Boulton.json
+++ b/data/members/Esrah Boulton.json
@@ -5,6 +5,5 @@
   "github": "https://github.com/esrahboulton",
   "linkedin": "https://ca.linkedin.com/in/esrah-boulton",
   "mastodon": null,
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Esrah Boulton.json
+++ b/data/members/Esrah Boulton.json
@@ -2,10 +2,6 @@
   "date": "2024-02-12T00:00",
   "name": "Esrah Boulton",
   "url": "https://www.esrahboulton.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/esrahboulton",
   "linkedin": "https://ca.linkedin.com/in/esrah-boulton",
   "mastodon": null,

--- a/data/members/Everyone's Web.json
+++ b/data/members/Everyone's Web.json
@@ -2,13 +2,8 @@
   "date": "2023-04-08T23:30",
   "name": "Everyone's Web",
   "url": "https://everyonesweb.com/experienceAnInaccessibleWeb",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": null,
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/everyonesweb"
+  "rss": null
 }

--- a/data/members/Floris Jansen.json
+++ b/data/members/Floris Jansen.json
@@ -2,14 +2,9 @@
   "date": "2023-07-20T15:50",
   "name": "Floris Jansen",
   "url": "https://fmjansen.com/#a11y-webring-club",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/florismartijnjansen/",
   "mastodon": "https://freeradical.zone/@floris",
   "rss": "https://fmjansen.com/feed.xml",
-  "twitter": "https://twitter.com/fmjansen",
   "accessibilityStatement": "https://fmjansen.com/accessibility.html"
 }

--- a/data/members/Foreverlikethis.json
+++ b/data/members/Foreverlikethis.json
@@ -2,13 +2,8 @@
   "date": "2023-01-28T12:59",
   "name": "foreverliketh.is",
   "url": "https://foreverliketh.is/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://indieweb.social/@accordionpolar",
-  "rss": "https://foreverliketh.is/blog/index.xml",
-  "twitter": null
+  "rss": "https://foreverliketh.is/blog/index.xml"
 }

--- a/data/members/Grace Snow.json
+++ b/data/members/Grace Snow.json
@@ -2,13 +2,8 @@
   "date": "2023-01-31T19:08",
   "name": "Grace Snow",
   "url": "https://fedmentor.dev/about/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/gracesnow/",
   "mastodon": null,
-  "rss": "https://fedmentor.dev/feed/feed.xml",
-  "twitter": "https://twitter.com/gracesnow"
+  "rss": "https://fedmentor.dev/feed/feed.xml"
 }

--- a/data/members/Ian Lloyd.json
+++ b/data/members/Ian Lloyd.json
@@ -2,13 +2,8 @@
   "date": "2023-10-06T00:00",
   "name": "Ian Lloyd",
   "url": "https://a11y-tools.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/lloydi",
   "linkedin": "https://www.linkedin.com/in/lloydi/",
   "mastodon": "https://mastodon.social/@lloydi",
-  "rss": null,
-  "twitter": "https://twitter.com/lloydi"
+  "rss": null
 }

--- a/data/members/Jan Maarten.json
+++ b/data/members/Jan Maarten.json
@@ -2,10 +2,6 @@
   "date": "2024-04-12T03:35",
   "name": "Jan Maarten",
   "url": "https://janmaarten.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/jmaarten/",
   "mastodon": "https://mastodon.social/@janmaarten",

--- a/data/members/Jasmine Rae Friedrich.json
+++ b/data/members/Jasmine Rae Friedrich.json
@@ -2,13 +2,8 @@
   "date": "2023-01-25T19:00",
   "name": "Jasmine Rae Friedrich",
   "url": "https://www.jasminemadethis.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/jasmine-friedrich/",
   "mastodon": "https://mastodon.social/@jrfbz",
-  "rss": null,
-  "twitter": "https://twitter.com/jrfbz"
+  "rss": null
 }

--- a/data/members/Jason Morris.json
+++ b/data/members/Jason Morris.json
@@ -2,10 +2,6 @@
   "date": "2023-11-13T00:00",
   "name": "Jason Morris",
   "url": "https://jasonmorris.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/jsnmrs",
   "linkedin": "https://www.linkedin.com/in/jsnmrs/",
   "accessibilityStatement": "https://jasonmorris.com/accessibility",

--- a/data/members/Jennifer Strickland.json
+++ b/data/members/Jennifer Strickland.json
@@ -2,10 +2,6 @@
   "date": "2023-01-26T15:02",
   "name": "Jennifer Strickland",
   "url": "https://jenstrickland.design/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "jenstrickland",
   "mastodon": "https://mastodon.social/@listening",
   "rss": null,

--- a/data/members/Josh Kim.json
+++ b/data/members/Josh Kim.json
@@ -2,13 +2,8 @@
   "date": "2023-02-26T00:00",
   "name": "Josh Kim",
   "url": "https://www.joshkimux.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/joshkimux/",
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/joshkimux"
+  "rss": null
 }

--- a/data/members/Katie Anderson.json
+++ b/data/members/Katie Anderson.json
@@ -2,13 +2,8 @@
   "date": "2023-05-05T00:00",
   "name": "Katie Anderson",
   "url": "https://www.k80anderson.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/k80anderson/",
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/kandersonnnn"
+  "rss": null
 }

--- a/data/members/Kehinde Adeleke.json
+++ b/data/members/Kehinde Adeleke.json
@@ -2,14 +2,9 @@
   "date": "2023-07-14T00:00",
   "name": "Kehinde Adeleke",
   "url": "https://www.kehinde.xyz/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://linkedin.com/in/adeleke5140",
   "accessibilityStatement": "https://www.kehinde.xyz/blog/web-accessibility",
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/adeleke5140"
+  "rss": null
 }

--- a/data/members/Kev Bonett.json
+++ b/data/members/Kev Bonett.json
@@ -2,13 +2,8 @@
     "date": "2023-11-17T00:00",
     "name": "Kev Bonett (basher)",
     "url": "https://basher.biz",
-    "employment": {
-      "hiring": false,
-      "seeking": false
-    },
     "github": "https://github.com/basher",
     "linkedin": "https://www.linkedin.com/in/kevbonett/",
     "mastodon": null,
-    "rss": null,
-    "twitter": null
+    "rss": null
 }

--- a/data/members/Luce Carević.json
+++ b/data/members/Luce Carević.json
@@ -2,13 +2,8 @@
   "date": "2023-02-12T00:00",
   "name": "Luce Carević",
   "url": "https://luce.carevic.eu/fr",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/lucecarevic/",
   "mastodon": "https://mastodon.design/@luce",
-  "rss": "https://luce.carevic.eu/fr/flux",
-  "twitter": null
+  "rss": "https://luce.carevic.eu/fr/flux"
 }

--- a/data/members/Mana Sugiyoshi.json
+++ b/data/members/Mana Sugiyoshi.json
@@ -2,13 +2,8 @@
   "date": "2023-04-01T00:00",
   "name": "Mana Sugiyoshi",
   "url": "https://www.maddy.codes/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/maddyscodes",
   "linkedin": "https://www.linkedin.com/in/manasugiyoshi/",
   "mastodon": null,
-  "rss": null,
-  "twitter": "https://twitter.com/manasugiyoshi"
+  "rss": null
 }

--- a/data/members/Marcus Herrmann.json
+++ b/data/members/Marcus Herrmann.json
@@ -2,13 +2,8 @@
   "date": "2023-01-22T19:08",
   "name": "Marcus Herrmann",
   "url": "https://marcus.io/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/marcusherrmann/",
   "mastodon": "https://mastodon.social/@marcus",
-  "rss": "https://marcus.io/feed",
-  "twitter": null
+  "rss": "https://marcus.io/feed"
 }

--- a/data/members/Matt Obee.json
+++ b/data/members/Matt Obee.json
@@ -2,10 +2,6 @@
   "date": "2023-01-22T21:10",
   "name": "Matt Obee",
   "url": "https://mattobee.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/mattobee",
   "linkedin": "https://linkedin.com/in/mattobee",
   "mastodon": "https://mastodon.social/@mattobee",

--- a/data/members/Matthew Deeprose.json
+++ b/data/members/Matthew Deeprose.json
@@ -2,13 +2,8 @@
   "date": "2023-01-26T07:57",
   "name": "Matthew Deeprose",
   "url": "https://matthewdeeprose.github.io/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/mattdeeprose/",
   "mastodon": "https://oldbytes.space/@vleguru",
-  "rss": "https://matthewdeeprose.github.io/feed.rss",
-  "twitter": "https://twitter.com/vleguru"
+  "rss": "https://matthewdeeprose.github.io/feed.rss"
 }

--- a/data/members/Matthew Hallonbacka.json
+++ b/data/members/Matthew Hallonbacka.json
@@ -2,13 +2,8 @@
   "date": "2023-04-04T00:00",
   "name": "Matthew Hallonbacka",
   "url": "https://mallonbacka.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/mallonbacka/",
   "mastodon": "https://mastodon.social/@mallonbacka",
-  "rss": "https://mallonbacka.com/feed.xml",
-  "twitter": null 
+  "rss": "https://mallonbacka.com/feed.xml"
 }

--- a/data/members/Mike Herchel.json
+++ b/data/members/Mike Herchel.json
@@ -2,13 +2,8 @@
   "date": "2023-01-25T16:27",
   "name": "Mike Herchel",
   "url": "https://herchel.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "http://www.linkedin.com/in/mherchel",
   "mastodon": "https://mastodon.social/@mherchel",
-  "twitter": "https://twitter.com/mikeherchel",
   "rss": "https://herchel.com/rss.xml"
 }

--- a/data/members/Mike Mai.json
+++ b/data/members/Mike Mai.json
@@ -2,13 +2,8 @@
   "date": "2023-02-21T00:00",
   "name": "Mike Mai",
   "url": "https://mikemai.net",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/mikemai/",
   "mastodon": "https://mastodon.social/@mikemai2awesome",
-  "rss": "https://mikemai.net/blog/feed.xml",
-  "twitter": "https://twitter.com/mikemai2awesome"
+  "rss": "https://mikemai.net/blog/feed.xml"
 }

--- a/data/members/Muath Khraisat.json
+++ b/data/members/Muath Khraisat.json
@@ -2,13 +2,8 @@
   "date": "2024-04-15T00:00",
   "name": "Muath Khraisat",
   "url": "https://phpmasteryhub.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/muath-khraisat",
   "mastodon": null,
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Rachel Cherry.json
+++ b/data/members/Rachel Cherry.json
@@ -3,13 +3,8 @@
   "name": "Rachel Cherry",
   "url": "https://bamadesigner.com/",
   "accessibilityStatement": null,
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/bamadesigner",
   "linkedin": "https://www.linkedin.com/in/rachelmcherry/",
   "mastodon": "https://higheredweb.social/web/@rachelcherry",
-  "rss": null,
-  "twitter": "https://twitter.com/bamadesigner"
+  "rss": null
 }

--- a/data/members/Rachele DiTullio.json
+++ b/data/members/Rachele DiTullio.json
@@ -2,13 +2,8 @@
   "date": "2023-01-21T03:35",
   "name": "Rachele DiTullio",
   "url": "https://racheleditullio.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/racheleditullio/",
   "mastodon": "https://mastodon.social/@racheled",
-  "rss": null,
-  "twitter": "https://twitter.com/racheleditullio"
+  "rss": null
 }

--- a/data/members/Ricky Onsman.json
+++ b/data/members/Ricky Onsman.json
@@ -2,13 +2,8 @@
   "date": "2023-10-09T00:00",
   "name": "Ricky Onsman",
   "url": "https://onsman.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/rickyonsman/",
   "mastodon": "https://aus.social/@onsman",
-  "rss": "https://onsman.com/feed/",
-  "twitter": "https://twitter.com/onsman"
+  "rss": "https://onsman.com/feed/"
 }

--- a/data/members/Ron Vaisman.json
+++ b/data/members/Ron Vaisman.json
@@ -2,13 +2,8 @@
   "date": "2023-01-30T22:05",
   "name": "Ron Vaisman",
   "url": "https://ronvaisman.dev/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/ron-vaisman/",
   "mastodon": "https://hachyderm.io/@ronv",
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Saptak S.json
+++ b/data/members/Saptak S.json
@@ -2,10 +2,6 @@
   "date": "2023-01-24T13:46",
   "name": "Saptak S.",
   "url": "https://saptaks.blog/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/saptaks",
   "linkedin": "https://linkedin.com/in/saptaks",
   "mastodon": "https://toots.dgplug.org/@saptaks",

--- a/data/members/Sara Joy.json
+++ b/data/members/Sara Joy.json
@@ -3,13 +3,8 @@
   "name": "Sara Joy",
   "url": "https://sarajoy.dev/",
   "accessibilityStatement": "https://sarajoy.dev/#a11y",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://front-end.social/@sarajw",
-  "rss": "https://sarajoy.dev/rss.xml",
-  "twitter": null
+  "rss": "https://sarajoy.dev/rss.xml"
 }

--- a/data/members/Sayan Sivakumaran.json
+++ b/data/members/Sayan Sivakumaran.json
@@ -3,13 +3,8 @@
   "name": "Sayan Sivakumaran",
   "url": "https://sayansivakumaran.com/",
   "accessibilityStatement": null,
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/sayan-sivakumaran-a70763239/",
   "mastodon": null,
-  "rss": "https://sayansivakumaran.com/rss.xml",
-  "twitter": null
+  "rss": "https://sayansivakumaran.com/rss.xml"
 }

--- a/data/members/Seirdy.json
+++ b/data/members/Seirdy.json
@@ -3,13 +3,8 @@
   "name": "Seirdy",
   "url": "https://seirdy.one/",
   "accessibilityStatement": "https://seirdy.one/meta/site-design/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": null,
   "mastodon": "https://pleroma.envs.net/@jrfbz",
-  "rss": "https://seirdy.one/atom.xml",
-  "twitter": null
+  "rss": "https://seirdy.one/atom.xml"
 }

--- a/data/members/Sharyn Morrow.json
+++ b/data/members/Sharyn Morrow.json
@@ -2,13 +2,8 @@
   "date": "2023-02-01T13:26",
   "name": "Sharyn Morrow",
   "url": "https://www.sharynmorrow.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/sharynm/",
   "mastodon": "https://mastodon.social/@sharyn",
-  "rss": "https://www.sharynmorrow.com/feed/",
-  "twitter": "https://twitter.com/massdistraction"
+  "rss": "https://www.sharynmorrow.com/feed/"
 }

--- a/data/members/Steve Barnett.json
+++ b/data/members/Steve Barnett.json
@@ -2,13 +2,8 @@
   "date": "2023-02-01T23:36",
   "name": "Steve Barnett",
   "url": "https://naga.co.za/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/steve-barnett/",
   "mastodon": null,
-  "rss": "https://naga.co.za/feed/",
-  "twitter": null
+  "rss": "https://naga.co.za/feed/"
 }

--- a/data/members/Steve Faulkner.json
+++ b/data/members/Steve Faulkner.json
@@ -2,13 +2,8 @@
   "date": "2023-01-22T19:10",
   "name": "Steve Faulkner",
   "url": "https://html5accessibility.com/stuff/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/steven-faulkner-3781ab1/",
   "mastodon": "https://mastodon.social/@SteveFaulkner",
-  "rss": "https://html5accessibility.com/stuff/feed",
-  "twitter": "https://twitter.com/SteveFaulkner"
+  "rss": "https://html5accessibility.com/stuff/feed"
 }

--- a/data/members/Steve Frenzel.json
+++ b/data/members/Steve Frenzel.json
@@ -3,13 +3,8 @@
   "name": "Steve Frenzel",
   "url": "https://stevefrenzel.dev/",
   "accessibilityStatement": "https://stevefrenzel.dev/accessibility/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": "https://github.com/stevefrenzel",
   "linkedin": "https://www.linkedin.com/in/stevefrenzel",
   "mastodon": "https://mastodon.online/@stvfrnzl",
-  "rss": "https://stevefrenzel.dev/rss.xml",
-  "twitter": null
+  "rss": "https://stevefrenzel.dev/rss.xml"
 }

--- a/data/members/Steve Woodson.json
+++ b/data/members/Steve Woodson.json
@@ -2,13 +2,8 @@
   "date": "2023-01-26T12:46",
   "name": "Steve Woodson",
   "url": "https://stevenwoodson.com/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/stevenwoodson/",
   "mastodon": "https://mastodon.online/@stevenwoodson",
-  "rss": "https://stevenwoodson.com/feed/feed.xml",
-  "twitter": "https://twitter.com/stevenwoodson"
+  "rss": "https://stevenwoodson.com/feed/feed.xml"
 }

--- a/data/members/Taner Aydın.json
+++ b/data/members/Taner Aydın.json
@@ -2,13 +2,8 @@
   "date": "2023-01-25T18:20",
   "name": "Taner Aydın",
   "url": "https://taner-aydin.dev/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/taner-aydın/",
   "mastodon": "https://indieweb.social/@a11yup",
-  "rss": "https://a11yup.com/rss.xml",
-  "twitter": null
+  "rss": "https://a11yup.com/rss.xml"
 }

--- a/data/members/Tevin Steinke.json
+++ b/data/members/Tevin Steinke.json
@@ -2,14 +2,9 @@
   "date": "2023-12-20T00:00",
   "name": "Tevin Steinke",
   "url": "https://www.frankensteinke.com",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "accessibilityStatement": "https://www.frankensteinke.com/accessibility-statement/",
   "github": "https://github.com/frankensteinke",
   "linkedin": null,
   "mastodon": null,
-  "rss": "https://www.frankensteinke.com/feed.xml",
-  "twitter": null
+  "rss": "https://www.frankensteinke.com/feed.xml"
 }

--- a/data/members/Tiffany Pender.json
+++ b/data/members/Tiffany Pender.json
@@ -2,13 +2,8 @@
   "date": "2023-03-09T00:00",
   "name": "Tiffany Pender",
   "url": "https://tiffanypender.com",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/tiffanypender/",
   "mastodon": "https://mastodon.social/@GeekBased",
-  "rss": null,
-  "twitter": "https://twitter.com/GeekBased"
+  "rss": null
 }

--- a/data/members/Todd Libby.json
+++ b/data/members/Todd Libby.json
@@ -2,13 +2,8 @@
   "date": "2023-01-30T03:09",
   "name": "Todd Libby",
   "url": "https://toddl.dev/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/todd-libby/",
   "mastodon": "https://a11y.info/@todd",
-  "rss": "https://toddl.de/feed/feed.xml",
-  "twitter": "https://twitter.com/toddlibby"
+  "rss": "https://toddl.de/feed/feed.xml"
 }

--- a/data/members/Trevor Pierce.json
+++ b/data/members/Trevor Pierce.json
@@ -3,13 +3,8 @@
   "name": "Trevor Pierce",
   "url": "https://continuumdesign.net",
   "accessibilityStatement": "https://continuumdesign.net/accessibility/",
-  "employment": {
-    "hiring": false,
-    "seeking": false
-  },
   "github": "https://github.com/1copenut",
   "linkedin": "https://www.linkedin.com/in/1copenut",
   "mastodon": null,
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/data/members/Wagner Beethoven.json
+++ b/data/members/Wagner Beethoven.json
@@ -5,10 +5,5 @@
   "github": "https://github.com/wagnerbeethoven",
   "linkedin": "https://www.linkedin.com/company/focoacessivel/",
   "mastodon": null,
-  "rss": "https://focoacessivel.com.br/feed/",
-  "twitter": "https://x.com/focoacessivel",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  }
+  "rss": "https://focoacessivel.com.br/feed/"
 }

--- a/data/members/Winnie Bosibori.json
+++ b/data/members/Winnie Bosibori.json
@@ -2,10 +2,6 @@
   "date": "2023-01-26T12:39",
   "name": "Winnie Bosibori",
   "url": "https://bosibori.netlify.app/",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/winnie-bosibori-b37601141/",
   "mastodon": "https://mstdn.social/@MissB",

--- a/data/members/Zoë Bijl.json
+++ b/data/members/Zoë Bijl.json
@@ -2,13 +2,8 @@
   "date": "2023-01-22T09:31",
   "name": "Zoë Bijl",
   "url": "https://moiety.me",
-  "employment": {
-    "hiring": false,
-    "seeking": true
-  },
   "github": null,
   "linkedin": "https://www.linkedin.com/in/zoë-bijl/",
   "mastodon": "https://front-end.social/@moiety",
-  "rss": null,
-  "twitter": null
+  "rss": null
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a11y-webring.club",
   "description": "A webring for digital accessibility practitioners.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "https://a11y-webring.club/",
   "author": {
     "name": "Eric Bailey",


### PR DESCRIPTION
This PR removes Twitter and employment metadata, as the redesign no longer supports this information.