### PR TITLE
Add Jasper Lai

### DIFF
--- a/data/members/Jasper Lai.json
+++ b/data/members/Jasper Lai.json
@@ -1,0 +1,12 @@
+{
+	"date": "2025-07-30T00:00",
+	"name": "Jasper Lai",
+	"url": "https://lai.nz",
+	"accessibilityStatement": "https://lai.nz/accessibility",
+	"bluesky": "https://bsky.app/profile/lai.nz",
+	"codeberg": null,
+	"github": "https://github.com/jaskfla",
+	"linkedin": "https://www.linkedin.com/in/jasperlai",
+	"mastodon": "https://mastodon.online/@jasperlai",
+	"rss": null
+}


### PR DESCRIPTION
You might spot that the links on my [homepage](https://lai.nz#webrings) have the `inert` attribute so aren’t accessible at the moment (to any user, regardless of input device); but this is purely while my application is pending!

The other non-pending wearings on the page are representative of what my next/previous links will look like 🙂 