### PR TITLE
Add support for `prefers-color-scheme: dark`

### DIFF
--- a/site.css
+++ b/site.css
@@ -64,6 +64,11 @@
       --color-secondary: #1f1f1f;
     }
 
+    @media screen and (prefers-color-scheme: dark) {
+      --color-primary: #ff7066;
+      --color-secondary: #1f1f1f;
+    }
+
     @media screen and (prefers-reduced-motion: reduce) {
       --transition-medium: none;
     }


### PR DESCRIPTION
This PR addresses https://github.com/ericwbailey/a11y-webring.club/issues/252. 

Previously the site did not honor dark mode settings, only an explicit choosing of the dark mode theme. This PR adds a `prefers-color-scheme: dark` media query, and then updates the color-related Custom Properties.