### PR TITLE
Add Plausible analytics

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -39,6 +39,11 @@ The webring is precompiled on Netlify. Nearly all content is static, save for [t
 
 [The webring code](https://a11y-webring.club/#list-the-webring-on-your-website) is entirely static HTML, and does not require CSS, JavaScript, or other technologies to work—Netlify handles this.
 
+## Analytics
+
+The webring uses [Plausible analytics](https://plausible.io/), a privacy-friendly service based out of Europe. It also uses a unique password and multifactor authentication.
+
+
 ## Evaluation of content
 
 Requests to be added to the webring are a manual process, where I evaluate the site and its content. This evaluation includes compliance with the [Code of Conduct](https://github.com/ericwbailey/a11y-webring.club/blob/main/.github/CODE_OF_CONDUCT.md), which prohibits harmful content.

--- a/includes/scripts.njk
+++ b/includes/scripts.njk
@@ -142,3 +142,9 @@ function initSiteColorScheme() {
 
 initSiteColorScheme();
 </script>
+
+<script async src="https://plausible.io/js/pa-vMpro0VoHpxYVBDJFRJAK.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>


### PR DESCRIPTION
This PR adds support for [Plausible analytics](https://plausible.io/), a privacy-conscious analytics service. It also updates `SECURITY.md` to mention the presence of Plausible.