### PR TITLE
Replace Mastodon with Bluesky in Andrew Hedges.json

### DIFF
--- a/data/members/Andrew Hedges.json
+++ b/data/members/Andrew Hedges.json
@@ -5,6 +5,6 @@
   "roles": [ "Operations leader", "Accessibility advocate" ],
   "github": "https://github.com/segdeha",
   "linkedin": "https://www.linkedin.com/in/andrewhedges/",
-  "mastodon": "https://mastodon.social/@segdeha",
+  "bluesky": "https://bsky.app/profile/segdeha.com",
   "rss": null
 }


### PR DESCRIPTION
I pretty much never check Mastodon, but am active on Bluesky.