### PR TITLE
Upgrade `main.yml` workflow to use Node 20.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Use Node.js 18.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
         cache: 'npm'
 
     - name: Install NPM dependencies


### PR DESCRIPTION
This PR updates `main.yml` to use Node 20.x, to address failing checks in https://github.com/ericwbailey/a11y-webring.club/pull/332.