### PR TITLE
Add Will Ringland

### DIFF
--- a/data/members/Will Ringland.json
+++ b/data/members/Will Ringland.json
@@ -1,0 +1,9 @@
+{
+  "date": "2026-08-20T00:00",
+  "name": "Will Ringland",
+  "url": "https://angrybunnyman.com/",
+  "roles": [ "Head of Accessibility" ],
+  "linkedin": "https://www.linkedin.com/in/will-ringland-162469110/",
+  "mastodon": "https://indieweb.social/@Angrybunnyman",
+  "rss": "https://angrybunnyman.com/rss"
+}


### PR DESCRIPTION
This PR adds Will Ringland to the webring, [as requested on Mastodon](https://indieweb.social/@Angrybunnyman/117129120336930097).